### PR TITLE
blacksmith:add wood storage

### DIFF
--- a/techs/paperwar/factions/knights/units/blacksmith/blacksmith.xml
+++ b/techs/paperwar/factions/knights/units/blacksmith/blacksmith.xml
@@ -21,7 +21,7 @@
 			<field value="land" />
 		</fields>
 		<properties>
-			
+
 		</properties>
 		<light enabled="false" />
 		<unit-requirements>
@@ -33,6 +33,7 @@
 			<resource name="wood" amount="150" />
 		</resource-requirements>
 		<resources-stored>
+			<resource name="wood" amount="800" />
 		</resources-stored>
 		<image path="images/blacksmith.bmp"/>
 		<image-cancel path="../archer/images/tech_cancel.bmp"/>
@@ -61,7 +62,7 @@
 			<speed value="300" />
 			<anim-speed value="50" />
 			<animation path="models/blacksmith.g3d" />
-			
+
 			<sound enabled="false" />
 		</skill>
 		<skill>
@@ -71,7 +72,7 @@
 			<speed value="600" />
 			<anim-speed value="150" />
 			<animation path="models/blacksmith.g3d" />
-			
+
 			<sound enabled="true" start-time="0.3">
 				<sound-file path="$COMMONDATAPATH/sounds/anvil1.wav"/>
 				<sound-file path="$COMMONDATAPATH/sounds/anvil2.wav"/>
@@ -87,7 +88,7 @@
 			<anim-speed value="300" />
 			<animation path="../castle/destruction_models/blacksmith_destruction.g3d" />
 			<particles value="true">
-				
+
 			</particles>
 			<sound enabled="true" start-time="0">
 				<sound-file path="$COMMONDATAPATH/sounds/tech_building_fall1.wav"/>
@@ -96,7 +97,7 @@
 		</skill>
 	</skills>
 	<commands>
-		
-		
+
+
 	</commands>
 </unit>


### PR DESCRIPTION
This allows the blacksmith to store wood, so it can be build near wood, and workers don't have to carry wood to the castle.